### PR TITLE
Replaced edgexfroundry with brand store's iotdevice-edgexfoundry

### DIFF
--- a/rpi-jcv-dangerous.json
+++ b/rpi-jcv-dangerous.json
@@ -124,10 +124,10 @@
             "id":"9IuGPw5BnC6jAgdi9O95WluQZqFEAi27"
         },
 	{
-	    "name": "edgexfoundry",
+	    "name": "iotdevice-edgexfoundry",
 	    "type": "app",
 	    "default-channel":"latest/stable",
-	    "id":"AZGf0KNnh8aqdkbGATNuRuxnt1GNRKkV"
+	    "id":"3GEp3VxaCUTBgPNSeFhd5OaFEoBtDBat"
         },
         {
             "name": "iotdevice-node-red-demo",

--- a/rpi-jcv.json
+++ b/rpi-jcv.json
@@ -126,10 +126,10 @@
             "id":"9IuGPw5BnC6jAgdi9O95WluQZqFEAi27"
 	},
 	{
-	    "name": "edgexfoundry",
+	    "name": "iotdevice-edgexfoundry",
 	    "type": "app",
 	    "default-channel":"latest/stable",
-	    "id":"AZGf0KNnh8aqdkbGATNuRuxnt1GNRKkV"
+	    "id":"3GEp3VxaCUTBgPNSeFhd5OaFEoBtDBat"
         },
         {
             "name": "iotdevice-node-red-demo",


### PR DESCRIPTION
The ces demo is based on edgex 2.3, which is EOL and has been deleted from the global store. 
This modification allows to keep installing edgex 2.3 from the iotdevice-edgexfoundry snap.